### PR TITLE
Not found in GitHub: default

### DIFF
--- a/grafana-dashboards/ae4g5gd05zm68a.json
+++ b/grafana-dashboards/ae4g5gd05zm68a.json
@@ -1,0 +1,7 @@
+{
+  "id": 1,
+  "schemaVersion": 17,
+  "title": "default",
+  "uid": "ae4g5gd05zm68a",
+  "version": 1
+}


### PR DESCRIPTION
This PR not found in github the Grafana dashboard `default` (UID: `ae4g5gd05zm68a`).