### PR TITLE
Not found in GitHub: default

### DIFF
--- a/grafana-dashboards/ae4pkj4q6tc00f.json
+++ b/grafana-dashboards/ae4pkj4q6tc00f.json
@@ -1,0 +1,7 @@
+{
+  "id": 4,
+  "schemaVersion": 17,
+  "title": "default",
+  "uid": "ae4pkj4q6tc00f",
+  "version": 1
+}


### PR DESCRIPTION
This PR not found in github the Grafana dashboard `default` (UID: `ae4pkj4q6tc00f`).