### PR TITLE
Different from GitHub: dashboard in sync folder 2 / also testing specfial symbols

### DIFF
--- a/helm-chart-grafana-crd/values.yaml
+++ b/helm-chart-grafana-crd/values.yaml
@@ -32,29 +32,29 @@ dashboards:
     folder_uid: ee577bp3sn4sgc
     json: '{"annotations": {"list": [{"builtIn": 1, "datasource": {"type": "grafana",
       "uid": "-- Grafana --"}, "enable": true, "hide": true, "iconColor": "rgba(0,
-      211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]}, "editable":
-      true, "fiscalYearStartMonth": 0, "graphTooltip": 0, "id": 474, "links": [],
-      "panels": [{"datasource": {"type": "grafana", "uid": "grafana"}, "fieldConfig":
-      {"defaults": {"color": {"mode": "palette-classic"}, "custom": {"axisBorderShow":
-      false, "axisCenteredZero": false, "axisColorMode": "text", "axisLabel": "",
-      "axisPlacement": "auto", "barAlignment": 0, "drawStyle": "line", "fillOpacity":
-      0, "gradientMode": "none", "hideFrom": {"legend": false, "tooltip": false, "viz":
-      false}, "insertNulls": false, "lineInterpolation": "linear", "lineWidth": 1,
-      "pointSize": 5, "scaleDistribution": {"type": "linear"}, "showPoints": "auto",
-      "spanNulls": false, "stacking": {"group": "A", "mode": "none"}, "thresholdsStyle":
-      {"mode": "off"}}, "mappings": [], "thresholds": {"mode": "absolute", "steps":
-      [{"color": "green", "value": null}, {"color": "red", "value": 80}]}}, "overrides":
-      []}, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}, "id": 1, "options": {"legend":
-      {"calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true},
-      "tooltip": {"mode": "single", "sort": "none"}}, "targets": [{"datasource": {"type":
-      "datasource", "uid": "grafana"}, "queryType": "randomWalk", "refId": "A"}],
-      "title": "Panel Title", "type": "timeseries"}], "schemaVersion": 39, "tags":
-      ["v0.0.1"], "templating": {"list": []}, "time": {"from": "now-6h", "to": "now"},
-      "timepicker": {}, "timezone": "browser", "title": "dashboard in sync folder
-      2 / also testing specfial symbols", "uid": "de577ddd7yfwgc", "version": 2, "weekStart":
-      ""}'
+      211, 255, 1)", "name": "Annotations & Alerts", "type": "dashboard"}]}, "description":
+      "added description", "editable": true, "fiscalYearStartMonth": 0, "graphTooltip":
+      0, "id": 474, "links": [], "panels": [{"datasource": {"type": "grafana", "uid":
+      "grafana"}, "fieldConfig": {"defaults": {"color": {"mode": "palette-classic"},
+      "custom": {"axisBorderShow": false, "axisCenteredZero": false, "axisColorMode":
+      "text", "axisLabel": "", "axisPlacement": "auto", "barAlignment": 0, "drawStyle":
+      "line", "fillOpacity": 0, "gradientMode": "none", "hideFrom": {"legend": false,
+      "tooltip": false, "viz": false}, "insertNulls": false, "lineInterpolation":
+      "linear", "lineWidth": 1, "pointSize": 5, "scaleDistribution": {"type": "linear"},
+      "showPoints": "auto", "spanNulls": false, "stacking": {"group": "A", "mode":
+      "none"}, "thresholdsStyle": {"mode": "off"}}, "mappings": [], "thresholds":
+      {"mode": "absolute", "steps": [{"color": "green"}, {"color": "red", "value":
+      80}]}}, "overrides": []}, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 0}, "id":
+      1, "options": {"legend": {"calcs": [], "displayMode": "list", "placement": "bottom",
+      "showLegend": true}, "tooltip": {"mode": "single", "sort": "none"}}, "targets":
+      [{"datasource": {"type": "datasource", "uid": "grafana"}, "queryType": "randomWalk",
+      "refId": "A"}], "title": "Panel Title", "type": "timeseries"}], "schemaVersion":
+      39, "tags": ["v0.0.2"], "templating": {"list": []}, "time": {"from": "now-6h",
+      "to": "now"}, "timepicker": {}, "timezone": "browser", "title": "dashboard in
+      sync folder 2 / also testing specfial symbols", "uid": "de577ddd7yfwgc", "version":
+      3, "weekStart": ""}'
     tags:
-    - v0.0.1
+    - v0.0.2
     title: dashboard in sync folder 2 / also testing specfial symbols
   fe40gkfjmzmrkf:
     folder_title: sync-folder


### PR DESCRIPTION
This PR different from github the Grafana dashboard `dashboard in sync folder 2 / also testing specfial symbols` (UID: `de577ddd7yfwgc`).